### PR TITLE
Fix for issue #3

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -5,7 +5,7 @@ name = "pypi"
 
 [packages]
 rdflib-jsonld = "==0.6.1"
-rdflib = ">=5.0.0"
+rdflib = ">=5.0.0, !=6.1.*"
 
 [dev-packages]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,5 +10,5 @@
 # `Pipfile.lock` and then regenerate `requirements*.txt`.
 ################################################################################
 
-rdflib>=5.0.0
 rdflib-jsonld==0.6.1
+rdflib>=5.0.0, !=6.1.*

--- a/tests/test_issue_3.py
+++ b/tests/test_issue_3.py
@@ -1,0 +1,16 @@
+import unittest
+
+from rdflib import Graph
+
+
+class TestRDFLIBExtraNamespaces(unittest.TestCase):
+    def test_extra_namespaces(self):
+        """ Make sure that the brick and 40+ other namespaces aren't in the default graph """
+        g = Graph()
+        g_namespaces = [ns for ns, url in g.namespaces()]
+        self.assertNotIn('brick', g_namespaces)
+        self.assertIn('rdf', g_namespaces)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ whitelist_externals = python
 commands=
     pip install rdflib~=5.0
     python -m unittest discover -s tests
-    pip install rdflib~=6.0
+    pip install rdflib~=6.0.2
     python -m unittest discover -s tests
     pip install rdflib-jsonld==0.6.2
     python -m unittest discover -s tests


### PR DESCRIPTION
Disallow rdflib 6.1.* because it has 40+ default prefixes pre-installed.

Reported issue to rdflib community w/ https://github.com/RDFLib/rdflib/issues/1676